### PR TITLE
Fix: Downloads pages do not update when filters are used.

### DIFF
--- a/NineLanCacheUI/src/app/(pages)/RecentDownloads/page.tsx
+++ b/NineLanCacheUI/src/app/(pages)/RecentDownloads/page.tsx
@@ -98,7 +98,7 @@ export default function RecentDownloads() {
       try {
         const newData = await fetchRecentDownloads(days, excludeIPs, "100");
         if (!cancelled) {
-          setData((prevData) => mergeDownloadEvents(prevData, newData));
+          setData(newData);
         }
       } catch (error) {
         console.error(error);

--- a/NineLanCacheUI/src/app/(pages)/RecentSteamDownloads/page.tsx
+++ b/NineLanCacheUI/src/app/(pages)/RecentSteamDownloads/page.tsx
@@ -101,7 +101,7 @@ export default function RecentSteamDownloads() {
       try {
         const newData = await fetchRecentSteamDownloads(days, excludeIPs, "100");
         if (!cancelled) {
-          setData((prevData) => mergeDownloadEvents(prevData, newData));
+          setData(newData);
         }
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Description
Fix: Downloads pages do not update when filters are used.

Closes #134
